### PR TITLE
Keyword search in flat description, new --no-cache and --max-monthly-fee arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Added new `--cache/--no-cache` flag, which allows you to disable the cache. The
+  default behaviour is still to use the cache, but you can disable it by using the
+  `--no-cache` flag. This is useful if you want to see all the results, and not just the
+  new ones. The cache is stored in the `.boligping_cache` file in the current directory.
+
 ### Changed
 - Changed the `--query` (`-q`) option to now search for the selected keywords in the
   description of the flat, rather than use Boligsiden.dk's own keywords, since many

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Changed
+- Changed the `--query` (`-q`) option to now search for the selected keywords in the
+  description of the flat, rather than use Boligsiden.dk's own keywords, since many
+  flats do not use these keywords. Remember that you can specify multiple queries with,
+  e.g., `bolig-ping <other-arguments> -q badekar -q altan`.
 
 
 ## [v1.2.0] - 2025-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added new `--min-monthly-fee` and `--max-monthly-fee` options to filter flats by
+  monthly fee. The default is no minimum or maximum monthly fee.
 - Added new `--cache/--no-cache` flag, which allows you to disable the cache. The
   default behaviour is still to use the cache, but you can disable it by using the
   `--no-cache` flag. This is useful if you want to see all the results, and not just the

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Get a ping when your dream flat in Denmark becomes available on Boligsiden.dk.
 
 ______________________________________________________________________
-[![Code Coverage](https://img.shields.io/badge/Coverage-75%25-yellowgreen.svg)](https://github.com/saattrupdan/bolig-ping/tree/main/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-73%25-yellow.svg)](https://github.com/saattrupdan/bolig-ping/tree/main/tests)
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://saattrupdan.github.io/bolig-ping)
 [![License](https://img.shields.io/github/license/saattrupdan/bolig-ping)](https://github.com/saattrupdan/bolig-ping/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/saattrupdan/bolig-ping)](https://github.com/saattrupdan/bolig-ping/commits/main)

--- a/src/bolig_ping/cli.py
+++ b/src/bolig_ping/cli.py
@@ -40,6 +40,20 @@ logger = logging.getLogger(__package__)
     help="The maximum price of the apartment, in DKK.",
 )
 @click.option(
+    "--min-monthly-fee",
+    type=int,
+    default=0,
+    show_default=True,
+    help="The minimum monthly fee of the apartment, in DKK.",
+)
+@click.option(
+    "--max-monthly-fee",
+    type=int,
+    default=int(1e9),
+    show_default=True,
+    help="The maximum monthly fee of the apartment, in DKK.",
+)
+@click.option(
     "--min-rooms",
     type=int,
     default=1,
@@ -90,6 +104,8 @@ def main(
     city: list[str],
     min_price: int,
     max_price: int,
+    min_monthly_fee: int,
+    max_monthly_fee: int,
     min_rooms: int,
     max_rooms: int,
     min_size: int,
@@ -111,6 +127,8 @@ def main(
         cities=cities,
         min_price=min_price,
         max_price=max_price,
+        min_monthly_fee=min_monthly_fee,
+        max_monthly_fee=max_monthly_fee,
         min_rooms=min_rooms,
         max_rooms=max_rooms,
         min_size=min_size,

--- a/src/bolig_ping/cli.py
+++ b/src/bolig_ping/cli.py
@@ -74,7 +74,12 @@ logger = logging.getLogger(__package__)
     show_default=True,
     help="Email address to send the notification to, or None to print to stdout.",
 )
-@click.option("--query", "-q", multiple=True, help="A query to filter the results by.")
+@click.option(
+    "--query",
+    "-q",
+    multiple=True,
+    help="A keyword that the flat description must contain.",
+)
 def main(
     city: list[str],
     min_price: int,
@@ -122,7 +127,7 @@ def main(
         else:
             logger.info(
                 "No email provided, so printing the flats here:\n\n"
-                + "\n\n".join(flat.to_html() for flat in flats)
+                + "\n\n".join(flat.to_text() for flat in flats)
             )
         store_to_cache(flats=flats, email=email or "no-email")
 

--- a/src/bolig_ping/data_models.py
+++ b/src/bolig_ping/data_models.py
@@ -16,6 +16,8 @@ class SearchQuery(BaseModel):
     cities: list[str]
     min_price: int
     max_price: int
+    min_monthly_fee: int
+    max_monthly_fee: int
     min_rooms: int
     max_rooms: int
     min_size: int

--- a/src/bolig_ping/data_models.py
+++ b/src/bolig_ping/data_models.py
@@ -1,8 +1,13 @@
 """Data models used in the project."""
 
+import logging
+from functools import cached_property
+
 import requests
 from bs4 import BeautifulSoup
 from pydantic import BaseModel
+
+logger = logging.getLogger(__package__)
 
 
 class SearchQuery(BaseModel):
@@ -49,7 +54,7 @@ class Flat(BaseModel):
     monthly_fee: int | None
     year: int | None
 
-    @property
+    @cached_property
     def description(self) -> str | None:
         """Get the description of the flat.
 
@@ -63,6 +68,11 @@ class Flat(BaseModel):
             long_lines = [line.strip() for line in lines if len(line.strip()) > 200]
             if long_lines:
                 return "\n".join(long_lines)
+            else:
+                logger.warning(
+                    f"Could not find description for flat {self.url}. The longest line "
+                    f"was {max(len(line) for line in lines)} characters long."
+                )
         return None
 
     def __hash__(self) -> int:

--- a/src/bolig_ping/scraper.py
+++ b/src/bolig_ping/scraper.py
@@ -112,6 +112,18 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
         # Ensure that the progress bar is at 100% at the end
         pbar.n = pbar.total
 
+    # Filter the flats if any keyword queries were given
+    if search_query.queries:
+        flats = [
+            flat
+            for flat in tqdm(iterable=flats, desc="Filtering flats based on keywords")
+            if flat.description is not None
+            and any(
+                query.lower() in flat.description.lower()
+                for query in search_query.queries
+            )
+        ]
+
     return flats
 
 

--- a/src/bolig_ping/scraper.py
+++ b/src/bolig_ping/scraper.py
@@ -112,6 +112,17 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
         # Ensure that the progress bar is at 100% at the end
         pbar.n = pbar.total
 
+    # Filter the flats based on the monthly fee
+    flats = [
+        flat
+        for flat in flats
+        if flat.monthly_fee is None
+        or (
+            flat.monthly_fee >= search_query.min_monthly_fee
+            and flat.monthly_fee <= search_query.max_monthly_fee
+        )
+    ]
+
     # Filter the flats if any keyword queries were given
     if search_query.queries:
         flats = [

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -17,6 +17,8 @@ class TestSearchQuery:
             cities=["københavn-n"],
             min_price=100,
             max_price=200,
+            min_monthly_fee=100,
+            max_monthly_fee=200,
             min_rooms=3,
             max_rooms=5,
             min_size=50,
@@ -29,6 +31,8 @@ class TestSearchQuery:
         assert search_query.cities == ["københavn-n"]
         assert search_query.min_price == 100
         assert search_query.max_price == 200
+        assert search_query.min_monthly_fee == 100
+        assert search_query.max_monthly_fee == 200
         assert search_query.min_rooms == 3
         assert search_query.min_size == 50
         assert search_query.queries == ["badekar"]

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -39,7 +39,7 @@ class TestSearchQuery:
         assert url == (
             "https://www.boligsiden.dk/by/københavn-n/tilsalg/ejerlejlighed"
             "?priceMin=100&priceMax=200&numberOfRoomsMin=3&numberOfRoomsMax=5"
-            "&areaMin=50&areaMax=100&text=badekar"
+            "&areaMin=50&areaMax=100"
         )
 
 


### PR DESCRIPTION
### Added
- Added new `--min-monthly-fee` and `--max-monthly-fee` options to filter flats by
  monthly fee. The default is no minimum or maximum monthly fee.
- Added new `--cache/--no-cache` flag, which allows you to disable the cache. The
  default behaviour is still to use the cache, but you can disable it by using the
  `--no-cache` flag. This is useful if you want to see all the results, and not just the
  new ones. The cache is stored in the `.boligping_cache` file in the current directory.

### Changed
- Changed the `--query` (`-q`) option to now search for the selected keywords in the
  description of the flat, rather than use Boligsiden.dk's own keywords, since many
  flats do not use these keywords. Remember that you can specify multiple queries with,
  e.g., `bolig-ping <other-arguments> -q badekar -q altan`.