### PR TITLE
Add new property types, catch invalid city names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   flats do not use these keywords. Remember that you can specify multiple queries with,
   e.g., `bolig-ping <other-arguments> -q badekar -q altan`.
 
+### Fixed
+- Now catches when an invalid city name is provided, and returns a helpful error
+  message. Previously, it would just print the raw traceback.
+
 
 ## [v1.2.0] - 2025-04-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Added new `--cache/--no-cache` flag, which allows you to disable the cache. The
+  default behaviour is still to use the cache, but you can disable it by using the
+  `--no-cache` flag. This is useful if you want to see all the results, and not just the
+  new ones. The cache is stored in the `.boligping_cache` file in the current directory.
+
 ### Changed
 - Changed the `--query` (`-q`) option to now search for the selected keywords in the
   description of the flat, rather than use Boligsiden.dk's own keywords, since many

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Changed
+- Changed the `--query` (`-q`) option to now search for the selected keywords in the
+  description of the flat, rather than use Boligsiden.dk's own keywords, since many
+  flats do not use these keywords. Remember that you can specify multiple queries with,
+  e.g., `bolig-ping <other-arguments> -q badekar -q altan`.
 
 
 ## [v1.2.0] - 2025-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added the ability to search for different property types, with the new
+  `--property-type` (`-t`) option. The available property types are `ejerlejlighed`,
+  `andelslejlighed` and `house`. You can specify multiple property types with, e.g.,
+  `bolig-ping <other-arguments> -t ejerlejlighed -t house`. It defaults to
+  `ejerlejlighed`, which is the only type that was previously supported.
 - Added new `--min-monthly-fee` and `--max-monthly-fee` options to filter flats by
   monthly fee. The default is no minimum or maximum monthly fee.
 - Added new `--cache/--no-cache` flag, which allows you to disable the cache. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added new `--min-monthly-fee` and `--max-monthly-fee` options to filter flats by
+  monthly fee. The default is no minimum or maximum monthly fee.
 - Added new `--cache/--no-cache` flag, which allows you to disable the cache. The
   default behaviour is still to use the cache, but you can disable it by using the
   `--no-cache` flag. This is useful if you want to see all the results, and not just the

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ The following options are available:
   used several times to search in multiple cities, e.g., `-c aarhus -c odense`.
 - `--min-price`: The minimum price of the property, in DKK. Default is no minimum price.
 - `--max-price`: The maximum price of the property, in DKK. Default is no maximum price.
+- `--min-monthly-fee`: The minimum monthly fee of the property, in DKK. Default is no
+  minimum monthly fee.
+- `--max-monthly-fee`: The maximum monthly fee of the property, in DKK. Default is no
+  maximum monthly fee.
 - `--min-rooms`: The minimum number of rooms in the property. Default is no minimum
   number of rooms.
 - `--max-rooms`: The maximum number of rooms in the property. Default is no maximum
@@ -78,7 +82,17 @@ The following options are available:
   minimum size.
 - `--max-size`: The maximum size of the property, in square meters. Default is no
   maximum size.
+- `--query/-q`: The query to search for in the property description. This argument can
+  be used several times to search for multiple queries, e.g., `-q badekar -q altan`.
+- `--property-type/-t`: The type of property to search for. The available property
+  types are `ejerlejlighed`, `andelslejlighed` and `house`. This argument can be used
+  several times to search for multiple property types, e.g., `-t ejerlejlighed -t house`.
+  Default is only searching for `ejerlejlighed`.
 - `--email`: The email address you want to receive the ping on. Note that this needs to
   have the `GMAIL_EMAIL` and `GMAIL_PASSWORD` environment variables set, as described
   above. Default is to use no email address, and instead print the propertys to the
   console.
+- `--cache/--no-cache`: Whether to use the cache or not. Default is to use the cache,
+  but you can disable it by using the `--no-cache` flag. This is useful if you want to
+  see all the results, and not just the new ones. The cache is stored in the
+  `.boligping_cache` file in the current directory.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following options are available:
   Default is only searching for `ejerlejlighed`.
 - `--email`: The email address you want to receive the ping on. Note that this needs to
   have the `GMAIL_EMAIL` and `GMAIL_PASSWORD` environment variables set, as described
-  above. Default is to use no email address, and instead print the propertys to the
+  above. Default is to use no email address, and instead print the properties to the
   console.
 - `--cache/--no-cache`: Whether to use the cache or not. Default is to use the cache,
   but you can disable it by using the `--no-cache` flag. This is useful if you want to

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Get a ping when your dream flat in Denmark becomes available on Boligsiden.dk.
 
 ______________________________________________________________________
-[![Code Coverage](https://img.shields.io/badge/Coverage-75%25-yellowgreen.svg)](https://github.com/saattrupdan/bolig-ping/tree/main/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-73%25-yellow.svg)](https://github.com/saattrupdan/bolig-ping/tree/main/tests)
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://saattrupdan.github.io/bolig-ping)
 [![License](https://img.shields.io/github/license/saattrupdan/bolig-ping)](https://github.com/saattrupdan/bolig-ping/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/saattrupdan/bolig-ping)](https://github.com/saattrupdan/bolig-ping/commits/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bolig Ping
 
-Get a ping when your dream flat in Denmark becomes available on Boligsiden.dk.
+Get a ping when your dream home in Denmark becomes available on Boligsiden.dk.
 
 ______________________________________________________________________
 [![Code Coverage](https://img.shields.io/badge/Coverage-73%25-yellow.svg)](https://github.com/saattrupdan/bolig-ping/tree/main/tests)
@@ -18,7 +18,7 @@ Developer:
 
 The easiest way to use the package is as a
 [uv](https://docs.astral.sh/uv/getting-started/installation/) tool. You can simply start
-searching for flats using the following command:
+searching for properties using the following command:
 
 ```bash
 uvx bolig-ping --city københavn
@@ -44,7 +44,7 @@ GMAIL_PASSWORD=<your-app-password>
 ```
 
 With this set up, you can now use the `--email` option to receive an email with new
-flats that match your search criteria:
+properties that match your search criteria:
 
 ```bash
 uvx bolig-ping --city københavn --email <your-email>
@@ -68,17 +68,17 @@ The following options are available:
 
 - `--city/-c` (required): The city you want to search in. This argument can be
   used several times to search in multiple cities, e.g., `-c aarhus -c odense`.
-- `--min-price`: The minimum price of the flat, in DKK. Default is no minimum price.
-- `--max-price`: The maximum price of the flat, in DKK. Default is no maximum price.
-- `--min-rooms`: The minimum number of rooms in the flat. Default is no minimum number
-  of rooms.
-- `--max-rooms`: The maximum number of rooms in the flat. Default is no maximum number
-  of rooms.
-- `--min-size`: The minimum size of the flat, in square meters. Default is no minimum
-  size.
-- `--max-size`: The maximum size of the flat, in square meters. Default is no maximum
-  size.
+- `--min-price`: The minimum price of the property, in DKK. Default is no minimum price.
+- `--max-price`: The maximum price of the property, in DKK. Default is no maximum price.
+- `--min-rooms`: The minimum number of rooms in the property. Default is no minimum
+  number of rooms.
+- `--max-rooms`: The maximum number of rooms in the property. Default is no maximum
+  number of rooms.
+- `--min-size`: The minimum size of the property, in square meters. Default is no
+  minimum size.
+- `--max-size`: The maximum size of the property, in square meters. Default is no
+  maximum size.
 - `--email`: The email address you want to receive the ping on. Note that this needs to
   have the `GMAIL_EMAIL` and `GMAIL_PASSWORD` environment variables set, as described
-  above. Default is to use no email address, and instead print the flats to the
+  above. Default is to use no email address, and instead print the propertys to the
   console.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "bolig_ping"
 version = "1.2.0.dev"
-description = "Get a ping when your dream flat becomes available."
+description = "Get a ping when your dream home becomes available."
 readme = "README.md"
 authors = [
     {name = "Dan Saattrup Nielsen", email = "saattrupdan@gmail.com"},

--- a/src/bolig_ping/__init__.py
+++ b/src/bolig_ping/__init__.py
@@ -1,1 +1,1 @@
-"""Get a ping when your dream flat becomes available."""
+"""Get a ping when your dream home becomes available."""

--- a/src/bolig_ping/cache.py
+++ b/src/bolig_ping/cache.py
@@ -1,58 +1,58 @@
-"""Cache to store already sent flats."""
+"""Cache to store already sent homes."""
 
 import json
 from pathlib import Path
 
-from .data_models import Flat
+from .data_models import Home
 
 
 def store_to_cache(
-    flats: list[Flat], email: str, cache_path: Path = Path(".boligping_cache")
+    homes: list[Home], email: str, cache_path: Path = Path(".boligping_cache")
 ) -> None:
-    """Store the flats to the cache.
+    """Store the homes to the cache.
 
     Args:
-        flats:
-            The flats to store in the cache.
+        homes:
+            The homes to store in the cache.
         email:
-            The receiver of the flats.
+            The receiver of the homes.
         cache_path (optional):
             The path to the cache file. Defaults to ".boligping_cache".
     """
-    flats = remove_cached_flats(flats=flats, email=email, cache_path=cache_path)
-    added_flats: set[tuple[str, str]] = set()
+    homes = remove_cached_homes(homes=homes, email=email, cache_path=cache_path)
+    added_homes: set[tuple[str, str]] = set()
     with cache_path.open("a") as file:
-        for flat in flats:
-            flat_id = flat.url.split("/")[-1]
-            if (flat_id, email) in added_flats:
+        for home in homes:
+            home_id = home.url.split("/")[-1]
+            if (home_id, email) in added_homes:
                 continue
-            flat_json = json.dumps(dict(id=flat_id, email=email))
-            file.write(f"{flat_json}\n")
-            added_flats.add((flat_id, email))
+            home_json = json.dumps(dict(id=home_id, email=email))
+            file.write(f"{home_json}\n")
+            added_homes.add((home_id, email))
 
 
-def remove_cached_flats(
-    flats: list[Flat], email: str, cache_path: Path = Path(".boligping_cache")
-) -> list[Flat]:
-    """Remove the cached flats from the list of flats.
+def remove_cached_homes(
+    homes: list[Home], email: str, cache_path: Path = Path(".boligping_cache")
+) -> list[Home]:
+    """Remove the cached homes from the list of homes.
 
     Args:
-        flats:
-            The flats to remove the cached flats from.
+        homes:
+            The homes to remove the cached homes from.
         email:
-            The receiver of the flats.
+            The receiver of the homes.
         cache_path (optional):
             The path to the cache file. Defaults to ".boligping_cache".
 
     Returns:
-        The flats without the cached flats.
+        The homes without the cached homes.
     """
     cache_path.touch(exist_ok=True)
     with cache_path.open() as file:
         for line in file:
             json_data = json.loads(line)
             if json_data["email"] == email:
-                flats = [
-                    flat for flat in flats if flat.url.split("/")[-1] != json_data["id"]
+                homes = [
+                    home for home in homes if home.url.split("/")[-1] != json_data["id"]
                 ]
-    return flats
+    return homes

--- a/src/bolig_ping/cli.py
+++ b/src/bolig_ping/cli.py
@@ -5,7 +5,7 @@ import os
 
 import click
 
-from .cache import remove_cached_flats, store_to_cache
+from .cache import remove_cached_homes, store_to_cache
 from .data_models import SearchQuery
 from .email import compose_email, send_email
 from .scraper import scrape_results
@@ -85,7 +85,16 @@ logger = logging.getLogger(__package__)
     "--query",
     "-q",
     multiple=True,
-    help="A keyword that the flat description must contain.",
+    help="A keyword that the home description must contain.",
+)
+@click.option(
+    "--property-type",
+    "-t",
+    type=click.Choice(["ejerlejlighed", "andelslejlighed", "house"]),
+    multiple=True,
+    default=None,
+    help="The type of property to search for. Default is only searching for "
+    "'ejerlejlighed'.",
 )
 @click.option(
     "--email",
@@ -98,7 +107,7 @@ logger = logging.getLogger(__package__)
     "--cache/--no-cache",
     default=True,
     show_default=True,
-    help="Whether to cache the flats that are found.",
+    help="Whether to cache the homes that are found.",
 )
 def main(
     city: list[str],
@@ -111,10 +120,11 @@ def main(
     min_size: int,
     max_size: int,
     query: list[str],
+    property_type: list[str],
     email: str | None,
     cache: bool,
 ) -> None:
-    """Search for flats in Denmark."""
+    """Search for homes in Denmark."""
     cities = [
         c.replace(" ", "-")
         .replace("ø", "oe")
@@ -134,16 +144,17 @@ def main(
         min_size=min_size,
         max_size=max_size,
         queries=query,
+        property_type=property_type or ["ejerlejlighed"],
     )
-    flats = scrape_results(search_query=search_query)
+    homes = scrape_results(search_query=search_query)
     if cache:
-        flats = remove_cached_flats(flats=flats, email=email or "no-email")
+        homes = remove_cached_homes(homes=homes, email=email or "no-email")
 
-    logger.info(f"Found {len(flats)} new flats that satisfy the search query.")
+    logger.info(f"Found {len(homes)} new homes that satisfy the search query.")
 
-    if flats:
+    if homes:
         if email is not None:
-            subject, contents = compose_email(flats=flats)
+            subject, contents = compose_email(homes=homes)
             send_email(
                 from_email=os.environ["GMAIL_EMAIL"],
                 password=os.environ["GMAIL_PASSWORD"],
@@ -151,14 +162,14 @@ def main(
                 subject=subject,
                 contents=contents,
             )
-            logger.info(f"Sent the flats to {email}.")
+            logger.info(f"Sent the homes to {email}.")
         else:
             logger.info(
-                "No email provided, so printing the flats here:\n\n"
-                + "\n\n".join(flat.to_text() for flat in flats)
+                "No email provided, so printing the homes here:\n\n"
+                + "\n\n".join(home.to_text() for home in homes)
             )
         if cache:
-            store_to_cache(flats=flats, email=email or "no-email")
+            store_to_cache(homes=homes, email=email or "no-email")
 
 
 if __name__ == "__main__":

--- a/src/bolig_ping/cli.py
+++ b/src/bolig_ping/cli.py
@@ -147,6 +147,12 @@ def main(
         property_type=property_type or ["ejerlejlighed"],
     )
     homes = scrape_results(search_query=search_query)
+    if homes is None:
+        logger.error(
+            "Could not find the city that you requested. Please double check the "
+            "spelling of the city name(s) and try again."
+        )
+        return
     if cache:
         homes = remove_cached_homes(homes=homes, email=email or "no-email")
 

--- a/src/bolig_ping/cli.py
+++ b/src/bolig_ping/cli.py
@@ -40,6 +40,20 @@ logger = logging.getLogger(__package__)
     help="The maximum price of the apartment, in DKK.",
 )
 @click.option(
+    "--min-monthly-fee",
+    type=int,
+    default=0,
+    show_default=True,
+    help="The minimum monthly fee of the apartment, in DKK.",
+)
+@click.option(
+    "--max-monthly-fee",
+    type=int,
+    default=int(1e9),
+    show_default=True,
+    help="The maximum monthly fee of the apartment, in DKK.",
+)
+@click.option(
     "--min-rooms",
     type=int,
     default=1,
@@ -90,6 +104,8 @@ def main(
     city: list[str],
     min_price: int,
     max_price: int,
+    min_monthly_fee: int,
+    max_monthly_fee: int,
     min_rooms: int,
     max_rooms: int,
     min_size: int,
@@ -111,6 +127,8 @@ def main(
         cities=cities,
         min_price=min_price,
         max_price=max_price,
+        min_monthly_fee=min_monthly_fee,
+        max_monthly_fee=max_monthly_fee,
         min_rooms=min_rooms,
         max_rooms=max_rooms,
         min_size=min_size,

--- a/src/bolig_ping/cli.py
+++ b/src/bolig_ping/cli.py
@@ -74,7 +74,12 @@ logger = logging.getLogger(__package__)
     show_default=True,
     help="Email address to send the notification to, or None to print to stdout.",
 )
-@click.option("--query", "-q", multiple=True, help="A query to filter the results by.")
+@click.option(
+    "--query",
+    "-q",
+    multiple=True,
+    help="A keyword that the flat description must contain.",
+)
 def main(
     city: list[str],
     min_price: int,
@@ -122,7 +127,7 @@ def main(
         else:
             logger.info(
                 "No email provided, so printing the flats here:\n\n"
-                + "\n\n".join(flat.to_html() for flat in flats)
+                + "\n\n".join(flat.to_text() for flat in flats)
             )
         store_to_cache(flats=flats, email=email or "no-email")
 

--- a/src/bolig_ping/data_models.py
+++ b/src/bolig_ping/data_models.py
@@ -16,6 +16,8 @@ class SearchQuery(BaseModel):
     cities: list[str]
     min_price: int
     max_price: int
+    min_monthly_fee: int
+    max_monthly_fee: int
     min_rooms: int
     max_rooms: int
     min_size: int

--- a/src/bolig_ping/data_models.py
+++ b/src/bolig_ping/data_models.py
@@ -38,7 +38,7 @@ class SearchQuery(BaseModel):
             property_type_names.append("andelslejlighed")
         if "house" in self.property_type:
             property_type_names.extend(["raekkehus", "villa", "landejendom"])
-        property_type_names = list(set(property_type_names))
+        property_type_names = sorted(set(property_type_names))
 
         url = "https://www.boligsiden.dk/by/{}/tilsalg/{}".format(
             ",".join(self.cities), ",".join(property_type_names)

--- a/src/bolig_ping/data_models.py
+++ b/src/bolig_ping/data_models.py
@@ -1,8 +1,13 @@
 """Data models used in the project."""
 
+import logging
+from functools import cached_property
+
 import requests
 from bs4 import BeautifulSoup
 from pydantic import BaseModel
+
+logger = logging.getLogger(__package__)
 
 
 class SearchQuery(BaseModel):
@@ -49,7 +54,7 @@ class Flat(BaseModel):
     monthly_fee: int | None
     year: int | None
 
-    @property
+    @cached_property
     def description(self) -> str | None:
         """Get the description of the flat.
 
@@ -63,6 +68,11 @@ class Flat(BaseModel):
             long_lines = [line.strip() for line in lines if len(line.strip()) > 200]
             if long_lines:
                 return "\n".join(long_lines)
+            else:
+                logger.warning(
+                    f"Could not find description for flat {self.url}. The longest line "
+                    f"was {max(len(line) for line in lines)} characters long."
+                )
         return None
 
     def __hash__(self) -> int:

--- a/src/bolig_ping/email.py
+++ b/src/bolig_ping/email.py
@@ -1,35 +1,35 @@
-"""Sending emails with flat listings."""
+"""Sending emails with home listings."""
 
 import yagmail
 from dotenv import load_dotenv
 
-from .data_models import Flat
+from .data_models import Home
 
 load_dotenv()
 
 
-def compose_email(flats: list[Flat]) -> tuple[str, str]:
-    """Compose an email with the given flats.
+def compose_email(homes: list[Home]) -> tuple[str, str]:
+    """Compose an email with the given homes.
 
     Args:
-        flats:
-            The flats to compose the email with.
+        homes:
+            The homes to compose the email with.
 
     Returns:
         A pair (subject, contents) for the email.
     """
-    match len(flats):
+    match len(homes):
         case 0:
-            raise ValueError("Cannot compose an email with no flats.")
+            raise ValueError("Cannot compose an email with no homes.")
         case 1:
-            subject = "[BoligPing] Found a new flat!"
-            contents = "Hi,\n\nI found a new flat that you might be interested in:\n\n"
+            subject = "[BoligPing] Found a new home!"
+            contents = "Hi,\n\nI found a new home that you might be interested in:\n\n"
         case _:
-            subject = f"[BoligPing] Found {len(flats)} new flats!"
+            subject = f"[BoligPing] Found {len(homes)} new homes!"
             contents = (
-                "Hi,\n\nI found some new flats that you might be interested in:\n\n"
+                "Hi,\n\nI found some new homes that you might be interested in:\n\n"
             )
-    contents += "\n\n".join(flat.to_html() for flat in flats)
+    contents += "\n\n".join(home.to_html() for home in homes)
     contents += "\n\nHave a splendid day!\n\nBest regards,\nBoligPing"
     return subject, contents
 

--- a/src/bolig_ping/scraper.py
+++ b/src/bolig_ping/scraper.py
@@ -112,6 +112,18 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
         # Ensure that the progress bar is at 100% at the end
         pbar.n = pbar.total
 
+    # Filter the flats if any keyword queries were given
+    if search_query.queries:
+        flats = [
+            flat
+            for flat in tqdm(iterable=flats, desc="Filtering flats based on keywords")
+            if flat.description is not None
+            and any(
+                query.lower() in flat.description.lower()
+                for query in search_query.queries
+            )
+        ]
+
     return flats
 
 

--- a/src/bolig_ping/scraper.py
+++ b/src/bolig_ping/scraper.py
@@ -112,6 +112,17 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
         # Ensure that the progress bar is at 100% at the end
         pbar.n = pbar.total
 
+    # Filter the flats based on the monthly fee
+    flats = [
+        flat
+        for flat in flats
+        if flat.monthly_fee is None
+        or (
+            flat.monthly_fee >= search_query.min_monthly_fee
+            and flat.monthly_fee <= search_query.max_monthly_fee
+        )
+    ]
+
     # Filter the flats if any keyword queries were given
     if search_query.queries:
         flats = [

--- a/src/bolig_ping/scraper.py
+++ b/src/bolig_ping/scraper.py
@@ -14,7 +14,7 @@ from .webdriver import Webdriver
 logger = logging.getLogger(__package__)
 
 
-def scrape_results(search_query: SearchQuery) -> list[Home]:
+def scrape_results(search_query: SearchQuery) -> list[Home] | None:
     """Scrape the results of a home search query.
 
     Args:
@@ -22,7 +22,7 @@ def scrape_results(search_query: SearchQuery) -> list[Home]:
             The search query to scrape results for.
 
     Returns:
-        A list of homes that satisfy the search query.
+        A list of homes that satisfy the search query, or None if no results were found.
 
     Raises:
         HTTPError:
@@ -31,6 +31,9 @@ def scrape_results(search_query: SearchQuery) -> list[Home]:
     url = search_query.get_url()
     logger.info(f"Fetching URL {url!r}...")
     webdriver = Webdriver().load(url=url)
+
+    if "Siden findes ikke" in webdriver.html:
+        return None
 
     # Close the cookie banner
     logger.info("Closing cookie banner...")

--- a/src/bolig_ping/scraper.py
+++ b/src/bolig_ping/scraper.py
@@ -1,4 +1,4 @@
-"""Scraping flats available satisfying the given criteria."""
+"""Scraping homes available satisfying the given criteria."""
 
 import logging
 import re
@@ -8,21 +8,21 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from tqdm.auto import tqdm
 
-from .data_models import Flat, SearchQuery
+from .data_models import Home, SearchQuery
 from .webdriver import Webdriver
 
 logger = logging.getLogger(__package__)
 
 
-def scrape_results(search_query: SearchQuery) -> list[Flat]:
-    """Scrape the results of a flat search query.
+def scrape_results(search_query: SearchQuery) -> list[Home]:
+    """Scrape the results of a home search query.
 
     Args:
         search_query:
             The search query to scrape results for.
 
     Returns:
-        A list of flats that satisfy the search query.
+        A list of homes that satisfy the search query.
 
     Raises:
         HTTPError:
@@ -59,19 +59,19 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
         raise ValueError("Could not find number of results.")
     num_results = int(num_results_match.group())
 
-    # Extract the flats from the first page
+    # Extract the homes from the first page
     logger.info("Scraping first page...")
     results = webdriver.find_elements(
         "//div[@data-testid='case-list-card' and "
         "contains(concat(' ', normalize-space(@class), ' '), ' shadow-card ')]"
     )
-    flats = [get_flat_from_result(result=result) for result in results]
+    homes = [get_home_from_result(result=result) for result in results]
 
     # Scrape the remaining pages
     with tqdm(desc="Scraping pages") as pbar:
         # Update the progress bar
         pbar.total = num_results
-        pbar.update(len(flats))
+        pbar.update(len(homes))
 
         # Calculate the number of pages
         num_pages = num_results // 50
@@ -87,10 +87,10 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
 
             # Get the results, where we keep trying in case the page hasn't changed
             # correctly
-            num_flats = len(flats)
-            new_flats = []
+            num_homes = len(homes)
+            new_homes = []
             num_attempts = 3
-            while len(flats) == num_flats:
+            while len(homes) == num_homes:
                 # Get the results
                 results = webdriver.find_elements(
                     "//div["
@@ -98,55 +98,55 @@ def scrape_results(search_query: SearchQuery) -> list[Flat]:
                     "concat(' ', normalize-space(@class), ' '), ' shadow-card ')"
                     "]"
                 )
-                new_flats = [get_flat_from_result(result=result) for result in results]
-                flats.extend(new_flats)
-                flats = list(set(flats))
+                new_homes = [get_home_from_result(result=result) for result in results]
+                homes.extend(new_homes)
+                homes = list(set(homes))
 
                 # Monitor the number of attempts and raise an error if we can't change
                 # the page
                 num_attempts -= 1
                 if num_attempts == 0:
                     raise ValueError("Could not change page.")
-            pbar.update(len(new_flats))
+            pbar.update(len(new_homes))
 
         # Ensure that the progress bar is at 100% at the end
         pbar.n = pbar.total
 
-    # Filter the flats based on the monthly fee
-    flats = [
-        flat
-        for flat in flats
-        if flat.monthly_fee is None
+    # Filter the homes based on the monthly fee
+    homes = [
+        home
+        for home in homes
+        if home.monthly_fee is None
         or (
-            flat.monthly_fee >= search_query.min_monthly_fee
-            and flat.monthly_fee <= search_query.max_monthly_fee
+            home.monthly_fee >= search_query.min_monthly_fee
+            and home.monthly_fee <= search_query.max_monthly_fee
         )
     ]
 
-    # Filter the flats if any keyword queries were given
+    # Filter the homes if any keyword queries were given
     if search_query.queries:
-        flats = [
-            flat
-            for flat in tqdm(iterable=flats, desc="Filtering flats based on keywords")
-            if flat.description is not None
+        homes = [
+            home
+            for home in tqdm(iterable=homes, desc="Filtering homes based on keywords")
+            if home.description is not None
             and any(
-                query.lower() in flat.description.lower()
+                query.lower() in home.description.lower()
                 for query in search_query.queries
             )
         ]
 
-    return flats
+    return homes
 
 
-def get_flat_from_result(result: WebElement) -> Flat:
-    """Get a flat from a result.
+def get_home_from_result(result: WebElement) -> Home:
+    """Get a home from a result.
 
     Args:
         result:
-            The result to get the flat from.
+            The result to get the home from.
 
     Returns:
-        The flat from the result.
+        The home from the result.
 
     Raises:
         ValueError:
@@ -192,7 +192,7 @@ def get_flat_from_result(result: WebElement) -> Flat:
             if re.search(pattern=regex, string=span_value) is not None:
                 values[name] = extract_number(span_value)
 
-    return Flat(url=url, address=address, **values)
+    return Home(url=url, address=address, **values)
 
 
 def extract_number(text: str) -> int | None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,16 +6,16 @@ from pathlib import Path
 import pytest
 
 from bolig_ping.cache import store_to_cache
-from bolig_ping.data_models import Flat
+from bolig_ping.data_models import Home
 
 
 class TestStoreToCache:
     """Tests for the store_to_cache function."""
 
     @pytest.fixture(scope="class")
-    def flat(self) -> Generator[Flat, None, None]:
-        """Return a Flat object."""
-        yield Flat(
+    def home(self) -> Generator[Home, None, None]:
+        """Return a Home object."""
+        yield Home(
             url="https://some.url",
             address="Some address",
             price=1000,
@@ -26,9 +26,9 @@ class TestStoreToCache:
         )
 
     @pytest.fixture(scope="class")
-    def another_flat(self) -> Generator[Flat, None, None]:
-        """Return another Flat object."""
-        yield Flat(
+    def another_home(self) -> Generator[Home, None, None]:
+        """Return another Home object."""
+        yield Home(
             url="https://another.url",
             address="Another address",
             price=2000,
@@ -38,19 +38,19 @@ class TestStoreToCache:
             year=2001,
         )
 
-    def test_flat_is_stored(self, flat: Flat) -> None:
-        """Test that a flat is stored."""
+    def test_home_is_stored(self, home: Home) -> None:
+        """Test that a home is stored."""
         cache_path = Path(".test_cache")
-        store_to_cache(flats=[flat], email="no-email", cache_path=cache_path)
+        store_to_cache(homes=[home], email="no-email", cache_path=cache_path)
         with cache_path.open() as file:
             assert file.read() == '{"id": "some.url", "email": "no-email"}\n'
         cache_path.unlink()
 
-    def test_multiple_flats_are_stored(self, flat: Flat, another_flat: Flat) -> None:
-        """Test that multiple flats are stored."""
+    def test_multiple_homes_are_stored(self, home: Home, another_home: Home) -> None:
+        """Test that multiple homes are stored."""
         cache_path = Path(".test_cache")
         store_to_cache(
-            flats=[flat, another_flat], email="no-email", cache_path=cache_path
+            homes=[home, another_home], email="no-email", cache_path=cache_path
         )
         with cache_path.open() as file:
             assert (
@@ -60,13 +60,13 @@ class TestStoreToCache:
             )
         cache_path.unlink()
 
-    def test_no_duplicates_are_stored(self, flat: Flat) -> None:
+    def test_no_duplicates_are_stored(self, home: Home) -> None:
         """Test that no duplicates are stored."""
         cache_path = Path(".test_cache")
-        store_to_cache(flats=[flat, flat], email="no-email", cache_path=cache_path)
+        store_to_cache(homes=[home, home], email="no-email", cache_path=cache_path)
         with cache_path.open() as file:
             assert file.read() == '{"id": "some.url", "email": "no-email"}\n'
-        store_to_cache(flats=[flat], email="no-email", cache_path=cache_path)
+        store_to_cache(homes=[home], email="no-email", cache_path=cache_path)
         with cache_path.open() as file:
             assert file.read() == '{"id": "some.url", "email": "no-email"}\n'
         cache_path.unlink()

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -17,6 +17,8 @@ class TestSearchQuery:
             cities=["københavn-n"],
             min_price=100,
             max_price=200,
+            min_monthly_fee=100,
+            max_monthly_fee=200,
             min_rooms=3,
             max_rooms=5,
             min_size=50,
@@ -29,6 +31,8 @@ class TestSearchQuery:
         assert search_query.cities == ["københavn-n"]
         assert search_query.min_price == 100
         assert search_query.max_price == 200
+        assert search_query.min_monthly_fee == 100
+        assert search_query.max_monthly_fee == 200
         assert search_query.min_rooms == 3
         assert search_query.min_size == 50
         assert search_query.queries == ["badekar"]

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -39,7 +39,7 @@ class TestSearchQuery:
         assert url == (
             "https://www.boligsiden.dk/by/københavn-n/tilsalg/ejerlejlighed"
             "?priceMin=100&priceMax=200&numberOfRoomsMin=3&numberOfRoomsMax=5"
-            "&areaMin=50&areaMax=100&text=badekar"
+            "&areaMin=50&areaMax=100"
         )
 
 

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 
 import pytest
 
-from bolig_ping.data_models import Flat, SearchQuery
+from bolig_ping.data_models import Home, SearchQuery
 
 
 class TestSearchQuery:
@@ -24,6 +24,7 @@ class TestSearchQuery:
             min_size=50,
             max_size=100,
             queries=["badekar"],
+            property_type=["ejerlejlighed"],
         )
 
     def test_create_search_query(self, search_query: SearchQuery) -> None:
@@ -41,19 +42,19 @@ class TestSearchQuery:
         """Test the `get_url` method."""
         url = search_query.get_url()
         assert url == (
-            "https://www.boligsiden.dk/by/københavn-n/tilsalg/ejerlejlighed"
-            "?priceMin=100&priceMax=200&numberOfRoomsMin=3&numberOfRoomsMax=5"
-            "&areaMin=50&areaMax=100"
+            "https://www.boligsiden.dk/by/københavn-n/tilsalg/ejerlejlighed,"
+            "villalejlighed?priceMin=100&priceMax=200&numberOfRoomsMin=3"
+            "&numberOfRoomsMax=5&areaMin=50&areaMax=100"
         )
 
 
-class TestFlat:
-    """Tests for the `Flat` data model."""
+class TestHome:
+    """Tests for the `Home` data model."""
 
     @pytest.fixture(scope="class")
-    def flat(self) -> Generator[Flat, None, None]:
-        """Return a `Flat` instance."""
-        yield Flat(
+    def home(self) -> Generator[Home, None, None]:
+        """Return a `Home` instance."""
+        yield Home(
             url="https://some.url",
             address="Some address",
             price=1000,
@@ -63,16 +64,16 @@ class TestFlat:
             year=2000,
         )
 
-    def test_create_flat(self, flat: Flat) -> None:
-        """Test creating a `Flat` instance."""
-        assert flat.url == "https://some.url"
-        assert flat.address == "Some address"
-        assert flat.price == 1000
-        assert flat.num_rooms == 3
-        assert flat.size == 100
-        assert flat.monthly_fee == 100
-        assert flat.year == 2000
+    def test_create_home(self, home: Home) -> None:
+        """Test creating a `Home` instance."""
+        assert home.url == "https://some.url"
+        assert home.address == "Some address"
+        assert home.price == 1000
+        assert home.num_rooms == 3
+        assert home.size == 100
+        assert home.monthly_fee == 100
+        assert home.year == 2000
 
-    def test_hash(self, flat: Flat) -> None:
+    def test_hash(self, home: Home) -> None:
         """Test the `__hash__` method."""
-        assert hash(flat) == hash(flat.url)
+        assert hash(home) == hash(home.url)

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -2,16 +2,16 @@
 
 import pytest
 
-from bolig_ping.data_models import Flat
+from bolig_ping.data_models import Home
 from bolig_ping.email import compose_email
 
 
 @pytest.mark.parametrize(
-    argnames=["flats", "expected"],
+    argnames=["homes", "expected"],
     argvalues=[
         (
             [
-                Flat(
+                Home(
                     url="https://some.url",
                     address="Some address",
                     price=1000,
@@ -22,8 +22,8 @@ from bolig_ping.email import compose_email
                 )
             ],
             (
-                "[BoligPing] Found a new flat!",
-                "Hi,\n\nI found a new flat that you might be interested in:\n\n"
+                "[BoligPing] Found a new home!",
+                "Hi,\n\nI found a new home that you might be interested in:\n\n"
                 "<a href='https://some.url'>Some address</a>\n"
                 "Price: 1,000 kr.\n"
                 "Number of rooms: 3\n"
@@ -35,7 +35,7 @@ from bolig_ping.email import compose_email
         ),
         (
             [
-                Flat(
+                Home(
                     url="https://some.url",
                     address="Some address",
                     price=1000,
@@ -44,7 +44,7 @@ from bolig_ping.email import compose_email
                     monthly_fee=100,
                     year=2000,
                 ),
-                Flat(
+                Home(
                     url="https://another.url",
                     address="Another address",
                     price=2000,
@@ -55,8 +55,8 @@ from bolig_ping.email import compose_email
                 ),
             ],
             (
-                "[BoligPing] Found 2 new flats!",
-                "Hi,\n\nI found some new flats that you might be interested in:\n\n"
+                "[BoligPing] Found 2 new homes!",
+                "Hi,\n\nI found some new homes that you might be interested in:\n\n"
                 "<a href='https://some.url'>Some address</a>\n"
                 "Price: 1,000 kr.\n"
                 "Number of rooms: 3\n"
@@ -73,9 +73,9 @@ from bolig_ping.email import compose_email
             ),
         ),
     ],
-    ids=["one_flat", "two_flats"],
+    ids=["one_home", "two_homes"],
 )
-def test_compose_email(flats: list[Flat], expected: str) -> None:
+def test_compose_email(homes: list[Home], expected: str) -> None:
     """Test that an email is composed."""
-    email = compose_email(flats=flats)
+    email = compose_email(homes=homes)
     assert email == expected


### PR DESCRIPTION
### Added
- Added the ability to search for different property types, with the new
  `--property-type` (`-t`) option. The available property types are `ejerlejlighed`,
  `andelslejlighed` and `house`. You can specify multiple property types with, e.g.,
  `bolig-ping <other-arguments> -t ejerlejlighed -t house`. It defaults to
  `ejerlejlighed`, which is the only type that was previously supported.

### Fixed
- Now catches when an invalid city name is provided, and returns a helpful error
  message. Previously, it would just print the raw traceback.